### PR TITLE
Update main.js

### DIFF
--- a/templates/shaper_helixultimate/js/main.js
+++ b/templates/shaper_helixultimate/js/main.js
@@ -65,6 +65,10 @@ jQuery(function ($) {
 		 *
 		 */
 		let $header = $('#sp-header');
+		
+		// Check if the header exists
+		if($header.length == 0) return;
+		
 		let stickyHeaderTop = $header.offset().top;
 
 		/**


### PR DESCRIPTION
When I disable predefined header, I get that console error:

```console
main.js:68 Uncaught TypeError: Cannot read property 'top' of undefined
    at getHeaderOffset (main.js:68)
    at handleStickiness (main.js:108)
    at HTMLDocument.<anonymous> (main.js:119)
    at u (jquery.min.js?8dd6370df8f937b43173bf7bf742d0f2:2)
    at Object.fireWith [as resolveWith] (jquery.min.js?8dd6370df8f937b43173bf7bf742d0f2:2)
    at Function.ready (jquery.min.js?8dd6370df8f937b43173bf7bf742d0f2:2)
    at HTMLDocument._ (jquery.min.js?8dd6370df8f937b43173bf7bf742d0f2:2)
```
I think you should check if the #sp-header is defined or exists. Otherwise, don't calculate the offset.