### PR TITLE
`social_share` and `show_vote` block update

### DIFF
--- a/plugins/system/helixultimate/overrides/com_content/article/default.php
+++ b/plugins/system/helixultimate/overrides/com_content/article/default.php
@@ -141,7 +141,7 @@ $isExpired  = JVERSION < 4
 					<?php echo LayoutHelper::render('joomla.content.rating', array('item' => $this->item, 'params' => $params)) ?>
 				</div>
 			<?php endif; ?>
-			<div>
+			<div class="social-share-block">
 				<?php echo LayoutHelper::render('joomla.content.social_share', $this->item); ?>
 			</div>
 		</div>

--- a/plugins/system/helixultimate/overrides/com_content/article/default.php
+++ b/plugins/system/helixultimate/overrides/com_content/article/default.php
@@ -134,9 +134,9 @@ $isExpired  = JVERSION < 4
 	endif; ?>
 
 	<?php if( ($tmpl_params->get('social_share') || $params->get('show_vote')) && !$this->print) : ?>
-		<div class="article-ratings-social-share d-flex justify-content-end">
+		<div class="article-ratings-social-share d-flex justify-content-around">
 			<?php if($params->get('show_vote')): ?>
-				<div class="me-auto align-self-center">	
+				<div class="align-self-center">	
 					<?php HTMLHelper::_('jquery.token'); ?>
 					<?php echo LayoutHelper::render('joomla.content.rating', array('item' => $this->item, 'params' => $params)) ?>
 				</div>

--- a/plugins/system/helixultimate/overrides/com_content/article/default.php
+++ b/plugins/system/helixultimate/overrides/com_content/article/default.php
@@ -135,12 +135,12 @@ $isExpired  = JVERSION < 4
 
 	<?php if( ($tmpl_params->get('social_share') || $params->get('show_vote')) && !$this->print) : ?>
 		<div class="article-ratings-social-share d-flex justify-content-end">
-			<div class="me-auto align-self-center">
-				<?php if($params->get('show_vote')): ?>
+			<?php if($params->get('show_vote')): ?>
+				<div class="me-auto align-self-center">	
 					<?php HTMLHelper::_('jquery.token'); ?>
 					<?php echo LayoutHelper::render('joomla.content.rating', array('item' => $this->item, 'params' => $params)) ?>
-				<?php endif; ?>
-			</div>
+				</div>
+			<?php endif; ?>
 			<div>
 				<?php echo LayoutHelper::render('joomla.content.social_share', $this->item); ?>
 			</div>


### PR DESCRIPTION
The following changes are being made in the pull request 

1. If `Voting` is disabled entire block should be disabled
2. A class added to the parent div of the `social_share` block
3. `justify-content-around` works better than `justify-content-end` for the social_share parent block