### PR TITLE
Fixed Coming soon validation, HFWU-139 & HFWU-151 a

### DIFF
--- a/plugins/system/helixultimate/assets/js/admin/helix-ultimate.js
+++ b/plugins/system/helixultimate/assets/js/admin/helix-ultimate.js
@@ -565,17 +565,25 @@ jQuery(function ($) {
                     if (data.status) {
                         let $previewFrame = document.getElementById('hu-template-preview');
                         $previewFrame.contentWindow.location.reload(true);
+
+                        Joomla.HelixToaster.success('Changes have been successfully saved!', 'Success');
+                        $('.hu-loading-msg').hide();
+                        $('.hu-done-msg').hide();
+                        $('.action-reset-drafts').hide();
+                        showSaveLoader(false);
+                    } else {
+                        Joomla.HelixToaster.error(data.message, 'Failed');
+                        $('.hu-loading-msg').hide();
+                        $('.hu-done-msg').hide();
+                        $('.action-reset-drafts').hide();
+                        showSaveLoader(false);
                     }
 
                     // Update the setvalues.
                     updateSetvalue();
+                    
                 },
                 complete() {
-                    Joomla.HelixToaster.success('Changes have been successfully saved!', 'Success');
-                    $('.hu-loading-msg').hide();
-                    $('.hu-done-msg').hide();
-                    $('.action-reset-drafts').hide();
-                    showSaveLoader(false);
                 },
                 error: function (err) {
                     console.error('error', err);

--- a/plugins/system/helixultimate/helixultimate.php
+++ b/plugins/system/helixultimate/helixultimate.php
@@ -71,7 +71,9 @@ class  PlgSystemHelixultimate extends CMSPlugin
 	 */
 	public function onAfterInitialise()
 	{
-		
+		if (JVERSION < 4) {
+			$this->registerBootstrap();	
+		}
 	}
 
 	/**

--- a/plugins/system/helixultimate/overrides/com_finder/search/default.php
+++ b/plugins/system/helixultimate/overrides/com_finder/search/default.php
@@ -12,16 +12,16 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 
-if(JVERSION < 4)
+if (JVERSION < 4)
 {
 	HTMLHelper::_('behavior.core');
 	HTMLHelper::addIncludePath(JPATH_COMPONENT . '/helpers/html');
-	
+
 	HTMLHelper::_('stylesheet', 'com_finder/finder.css', array('version' => 'auto', 'relative' => true));
 	HTMLHelper::_('stylesheet', 'vendor/awesomplete/awesomplete.css', array('version' => 'auto', 'relative' => true));
-	
+
 	Text::script('MOD_FINDER_SEARCH_VALUE', true);
-	
+
 	HTMLHelper::_('script', 'com_finder/finder.js', array('version' => 'auto', 'relative' => true));
 }
 else

--- a/plugins/system/helixultimate/overrides/com_finder/search/default_result.php
+++ b/plugins/system/helixultimate/overrides/com_finder/search/default_result.php
@@ -40,6 +40,14 @@ if ($show_description)
 
 $route = $this->result->route;
 
+$showImage  = $this->params->get('show_image', 0);
+$imageClass = $this->params->get('image_class', '');
+$extraAttr  = [];
+
+if ($showImage && !empty($this->result->imageUrl) && $imageClass !== '') {
+    $extraAttr['class'] = $imageClass;
+}
+
 // Get the route with highlighting information.
 if (!empty($this->query->highlight)
 	&& empty($this->result->mime)
@@ -51,6 +59,25 @@ if (!empty($this->query->highlight)
 
 ?>
 <li>
+	<?php if ($showImage && isset($this->result->imageUrl)) : ?>
+		<?php 
+			$imageUrl = $this->result->imageUrl;
+			$imageAlt = $this->result->imageAlt;
+			if (!empty($this->result->params->get('helix_ultimate_image'))) {
+				$imageUrl = $this->result->params->get('helix_ultimate_image');
+				$imageAlt = $this->result->title;
+			}
+		?>
+        <figure class="<?php echo htmlspecialchars($imageClass, ENT_COMPAT, 'UTF-8'); ?> result__image">
+            <?php if ($this->params->get('link_image') && $this->result->route) : ?>
+                <a href="<?php echo Route::_($this->result->route); ?>">
+                    <?php echo HTMLHelper::_('image', $imageUrl, $imageAlt, $extraAttr); ?>
+                </a>
+            <?php else : ?>
+                <?php echo HTMLHelper::_('image', $imageUrl, $imageAlt, $extraAttr); ?>
+            <?php endif; ?>
+        </figure>
+    <?php endif; ?>
 	<h4 class="result-title <?php echo $mime; ?>">
 		<a href="<?php echo Route::_($route); ?>">
 			<?php echo $this->result->title; ?>

--- a/plugins/system/helixultimate/src/Platform/Request.php
+++ b/plugins/system/helixultimate/src/Platform/Request.php
@@ -10,6 +10,8 @@ namespace HelixUltimate\Framework\Platform;
 
 defined('_JEXEC') or die();
 
+use DateTime;
+use Exception;
 use HelixUltimate\Framework\HttpResponse\Response;
 use HelixUltimate\Framework\Platform\Blog;
 use HelixUltimate\Framework\Platform\Helper;
@@ -228,6 +230,16 @@ class Request
 		Session::checkToken() or die(json_encode($this->report));
 
 		$data = $_POST;
+
+		$dateStatus = $this->validateDate($data['comingsoon_date']);
+
+		if (!$dateStatus) {
+			$this->report['status'] = false;
+			$this->report['message'] = 'Coming Soon Date for Countdown is invalid';
+			$this->report['isDrafted'] = Helper::isDrafted();
+			return;
+		}
+		
 		$inputs = $this->filterInputs($data);
 
 		if (!$this->id || !is_int($this->id))
@@ -258,6 +270,13 @@ class Request
 			$this->report['message'] = 'Style changed successfully';
 			$this->report['isDrafted'] = Helper::isDrafted();
 		}
+	}
+
+	private function validateDate($date, $format = 'Y-m-d')
+	{
+		$d = DateTime::createFromFormat($format, $date);
+		// The Y ( 4 digits year ) returns TRUE for any integer with any number of digits so changing the comparison from == to === fixes the issue.
+		return $d && $d->format($format) === $date;
 	}
 
 	private function draftTemplateStyle()

--- a/plugins/system/helixultimate/src/Platform/Request.php
+++ b/plugins/system/helixultimate/src/Platform/Request.php
@@ -231,6 +231,7 @@ class Request
 
 		$data = $_POST;
 
+		$data['comingsoon_date'] = date('Y-m-d', strtotime($data['comingsoon_date']));
 		$dateStatus = $this->validateDate($data['comingsoon_date']);
 
 		if (!$dateStatus) {

--- a/templates/shaper_helixultimate/options.json
+++ b/templates/shaper_helixultimate/options.json
@@ -51,7 +51,7 @@
 	"contact_time": "",
 	"comingsoon_title": "Coming Soon Title",
 	"comingsoon_content": "Coming soon content",
-	"comingsoon_date": "1-1-2025",
+	"comingsoon_date": "2025-01-01",
 	"comingsoon_logo": "",
 	"comingsoon_bg_image": "",
 	"error_logo": "",


### PR DESCRIPTION
`Fixed` Coming soon page validation
`Fixed - HFWU-139` Date for Countdown broken if site language is not English
`Fixed - HFWU-151` Finder component override doesn't have images from articles like original finder from Casopea template + hightlight

HFWU-151
<img width="995" alt="image" src="https://github.com/JoomShaper/helix-ultimate/assets/42798816/2d87f271-af39-420f-b9e6-c9601cc00f08">

Task Url
https://ollyo.atlassian.net/browse/HFWU-139
https://ollyo.atlassian.net/browse/HFWU-151