### PR TITLE
fix: getModules method returns duplicated entries

### DIFF
--- a/plugins/system/helixultimate/layout/megaMenu/modules.php
+++ b/plugins/system/helixultimate/layout/megaMenu/modules.php
@@ -25,8 +25,12 @@ $modules = Helper::getModules($keyword);
 		<?php foreach ($modules as $module): ?>
 			<div class="col-4 hu-megamenu-column">
 				<div class="hu-megamenu-module-item">
+					<div style="font-size: 0.8em">#<?php echo $module->id; ?></div>
 					<strong class="hu-megamenu-module-title"><?php echo $module->title; ?></strong>
 					<p class="hu-megamenu-module-desc"><?php echo (strlen($module->desc) > 80 ? substr($module->desc, 0, 80) . '...' : $module->desc); ?></p>
+					<div style="font-size: 0.8em">
+						<?php echo $module->published == '1' ? '<span style="color:green">Published</span>' : '<span style="color: slategrey">Unpublished</span>' ?>
+					</div>
 					<button type="button" role="button" class="hu-btn hu-btn-default hu-megamenu-insert-module" data-module="<?php echo $module->id; ?>"><?php echo Text::_('HELIX_ULTIMATE_MODULE_INSERT'); ?></button>
 				</div>
 			</div>

--- a/plugins/system/helixultimate/src/Platform/Helper.php
+++ b/plugins/system/helixultimate/src/Platform/Helper.php
@@ -416,9 +416,11 @@ class Helper
 		{
 			$db = Factory::getDbo();
 			$query = $db->getQuery(true);
-			$query->select('DISTINCT m.id, m.title, m.module, m.position, m.params, e.manifest_cache')
+			$query->select('DISTINCT m.id, m.title, m.module, m.position, m.params, m.published, e.manifest_cache')
 				->from($db->quoteName('#__modules', 'm'))
-				->where($db->quoteName('m.client_id') . ' = 0');
+				->where($db->quoteName('m.client_id') . ' = 0')
+				->where($db->quoteName('e.client_id') . ' = 0') // Select only site extensions. This prevents returning duplicate entry for same module
+                ->where($db->quoteName('m.published'). ' != -2'); // Don't show trashed items, can parameterized.
 			$query->join('LEFT', $db->quoteName('#__extensions', 'e') . ' ON (' . $db->quoteName('e.element') . ' = ' . $db->quoteName('m.module') . ')');
 			
 			if (!empty($keyword))


### PR DESCRIPTION
I encountered an issue in the module selection process within the megamenu builder. The getModules method in the Helper.php file was returning duplicate entries. This problem was caused by a join statement involving the extensions table, which can contain entries with the same name for both admin and site contexts.

Additionally, I have added information to the module selection view to indicate which modules are published and display their respective IDs.