### PR TITLE
Fix the checkbox field issue that Joomla 5.2.4 introduced

### DIFF
--- a/plugins/system/helixultimate/src/Platform/Settings.php
+++ b/plugins/system/helixultimate/src/Platform/Settings.php
@@ -171,9 +171,8 @@ class Settings
 		 */
 		$formXml = $this->form->getXml();
 
-		// Patch for an issue introduced in Joomla 5.2.4 for the checkbox field.
-		// If the default value is equal to '0' in the checkbox field now joomla
-		// acts weirdly. So, set the default value to empty string if it's '0' previously.
+		// In Joomla 5.2.4, a bug was introduced where checkbox fields with a default value of '0'
+		// behave incorrectly. As a workaround, we set any '0' default values to an empty string.
 		// @since 2.1.2 & joomla 5.2.4
 		if (!empty($formXml))
 		{

--- a/plugins/system/helixultimate/src/Platform/Settings.php
+++ b/plugins/system/helixultimate/src/Platform/Settings.php
@@ -171,6 +171,26 @@ class Settings
 		 */
 		$formXml = $this->form->getXml();
 
+		// Patch for an issue introduced in Joomla 5.2.4 for the checkbox field.
+		// If the default value is equal to '0' in the checkbox field now joomla
+		// acts weirdly. So, set the default value to empty string if it's '0' previously.
+		// @since 2.1.2 & joomla 5.2.4
+		if (!empty($formXml))
+		{
+			foreach ($formXml->fieldset as $fieldset)
+			{
+				foreach ($fieldset->field as $field)
+				{
+					$fieldType = (string) $field['type'];
+
+					if ($fieldType === 'checkbox' && strval($field['default'] ?? '') === '0')
+					{
+						$field['default'] = '';
+					}
+				}
+			}
+		}
+
 		if (!empty($formXml))
 		{
 			for ($i = 0; $i < $formXml->count(); ++$i)

--- a/plugins/system/helixultimate/src/fields/helixfont.php
+++ b/plugins/system/helixultimate/src/fields/helixfont.php
@@ -64,6 +64,7 @@ class JFormFieldHelixfont extends FormField
 		$webfonts   = json_decode($json ?? "");
 		$items      = $webfonts->items;
 		$value      = json_decode($this->value ?? "");
+		$font 		= null;
 
 		if (isset($value->fontFamily))
 		{


### PR DESCRIPTION
- The issue is patched by replacing the `default="0"` to `default=""` programmatically instead of removing the `default="0"` from the `.xml` files.
@siddik-web 