### PR TITLE
solve the error in W3C validator

### DIFF
--- a/plugins/system/helixultimate/layouts/frontend/conponentarea.php
+++ b/plugins/system/helixultimate/layouts/frontend/conponentarea.php
@@ -15,7 +15,7 @@ $doc = Factory::getDocument();
 $data = $displayData;
 ?>
 
-<main id="sp-component" class="<?php echo $data->settings->className; ?>">
+<div id="sp-component" class="<?php echo $data->settings->className; ?>">
 	<div class="sp-column <?php echo $data->settings->custom_class; ?>">
 		<jdoc:include type="message" />
 
@@ -33,4 +33,4 @@ $data = $displayData;
 			</div>
 		<?php endif ?>
 	</div>
-</main>
+</div>

--- a/templates/shaper_helixultimate/index.php
+++ b/templates/shaper_helixultimate/index.php
@@ -162,7 +162,9 @@ if ($custom_js = $this->params->get('custom_js', null))
 		<div class="body-wrapper">
 			<div class="body-innerwrapper">
 				<?php echo $theme->getHeaderStyle(); ?>
-				<?php $theme->render_layout(); ?>
+				<main id="sp-main">
+					<?php $theme->render_layout(); ?>
+				</main>
 			</div>
 		</div>
 


### PR DESCRIPTION
Problem 7 and 10 -On an article W3C reports one error: <main id="sp-component" class="col-lg-12 "> - Error: The main element must not appear as a descendant of the section element. 

**Fix:** Restructured `<main>` tag to resolve W3C validation error
Replaced nested `<main>` with `<div>` and moved `<main>` outside `<section>` to ensure valid HTML structure.
