### PR TITLE
Fix: Remove unit from img height attribute in DOM

### DIFF
--- a/templates/shaper_helixultimate/features/logo.php
+++ b/templates/shaper_helixultimate/features/logo.php
@@ -114,7 +114,8 @@ class HelixUltimateFeatureLogo
 					$srcset .= Uri::root() . $retinaLogo . ' 2x';
 				}
 				$logoWithUrl = Uri::root() . $defaultLogo;
-				$attrLogoHeight = $this->params->get('logo_height', '') ?? '0px';
+				$attrLogoHeightRaw = $this->params->get('logo_height', '');
+				$attrLogoHeight = (int) filter_var($attrLogoHeightRaw, FILTER_SANITIZE_NUMBER_INT);
 				$siteLogo = "
 				<img class='logo-image {$custom_logo_class}'
 					srcset='{$srcset}'


### PR DESCRIPTION
According to problem 11 , i solve it by replacing `height="60px"` with `height="60"` in DOM output to comply with HTML standards and improve validation. is this sentence is correct , make it corect