### PR TITLE
Fix image upload failure when memory limit is set to -1 (unlimited)

### DIFF
--- a/plugins/system/helixultimate/src/Platform/Blog.php
+++ b/plugins/system/helixultimate/src/Platform/Blog.php
@@ -67,7 +67,7 @@ class Blog
 				$postMaxSize 	= $mediaHelper->toBytes(ini_get('post_max_size'));
 				$memoryLimit 	= $mediaHelper->toBytes(ini_get('memory_limit'));
 
-				if (($postMaxSize > 0 && $contentLength > $postMaxSize) || ($memoryLimit !== -1 && $contentLength > $memoryLimit))
+				if (($postMaxSize > 0 && $contentLength > $postMaxSize) || ($memoryLimit > 0 && $contentLength > $memoryLimit)) 
 				{
 					$report['status'] = false;
 					$report['output'] = Text::_('Total size of upload exceeds the limit.');


### PR DESCRIPTION
Resolved a bug where image uploads failed under article->Blog Media->Featured Image option, when the PHP memory limit was set to -1 (unlimited). Adjusted memory checks to correctly handle unlimited configurations and ensure consistent upload behaviour.