### PR TITLE
fix: remove duplicate <meta charset> tag in maintenance mode

### DIFF
--- a/plugins/system/helixultimate/overrides/layouts/comingsoon.php
+++ b/plugins/system/helixultimate/overrides/layouts/comingsoon.php
@@ -45,7 +45,6 @@ $site_title = $app->get('sitename');
 <!doctype html>
 <html class="coming-soon" lang="<?php echo $language; ?>" dir="<?php echo $direction; ?>">
 	<head>
-		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 		<?php
 			$theme->head();


### PR DESCRIPTION
Resolved an issue where multiple <meta charset> tags were being rendered in maintenance mode. This fix ensures only a single valid <meta charset> tag appears in the document head, improving HTML validity.