### PR TITLE
Fix: Improve offcanvas accessibility and focus management

### DIFF
--- a/templates/shaper_helixultimate/offcanvas/1-LeftAlign/canvas.php
+++ b/templates/shaper_helixultimate/offcanvas/1-LeftAlign/canvas.php
@@ -38,7 +38,7 @@ $menuModule = Helper::createModule('mod_menu', [
 
 $searchModule = Helper::getSearchModule();
 ?>
-<div class="offcanvas-menu">
+<div class="offcanvas-menu left-1" tabindex="-1" inert>
 	<div class="d-flex align-items-center p-3 pt-4">
 		<?php 
 			if ($params->get('offcanvas_enable_logo', 0)) {


### PR DESCRIPTION
- Sets initial focus to the first interactive element in the offcanvas menu
- Traps tab/shift+tab within offcanvas to prevent background tabbing
- Adds inert attribute to background content for screen reader compliance
- Resolves WCAG focus management issue as reported in #426
