### PR TITLE
Fix preset CSS loading in Helix Ultimate error template

### DIFF
--- a/templates/shaper_helixultimate/error.php
+++ b/templates/shaper_helixultimate/error.php
@@ -209,15 +209,12 @@ $theme_url = Uri::base(true) . '/templates/'. $this->template;
 		<link href="<?php echo $theme_url . '/css/font-awesome.min.css'; ?>" rel="stylesheet">
 		<link href="<?php echo $theme_url . '/css/template.css'; ?>" rel="stylesheet">
 		<?php
-			$preset = $params->get('preset', json_encode(['preset' => 'preset1']));
-
-			if (!empty($preset->preset))
-			{
-				$preset = $preset->preset;
-			}
+			// Fix the preset loading
+			$presetData = json_decode($params->get('preset', '{"preset":"preset1"}'));
+			$preset = isset($presetData->preset) ? $presetData->preset : 'default';
 		?>
 
-		<link href="<?php echo $theme_url . '/css/presets/' . $preset . '.css'; ?>" rel="stylesheet">
+		<link href="<?php echo $theme_url . '/css/presets/' . htmlspecialchars($preset, ENT_QUOTES, 'UTF-8') . '.css'; ?>" rel="stylesheet">
 		
 		<?php
 			if ($params->get('error_font_load')) {


### PR DESCRIPTION
This PR addresses issue #394 where the error template generates 404 errors by attempting to load non-existent preset CSS files.