### PR TITLE
refactor(layout): improve semantic html structure and section rendering

### DIFF
--- a/plugins/system/helixultimate/layouts/frontend/generate.php
+++ b/plugins/system/helixultimate/layouts/frontend/generate.php
@@ -54,7 +54,7 @@ if (!empty($template->params->get('layout'))) {
 extract($displayData);
 ?>
 
-<<?php echo $semantic; ?> id="<?php echo $id ?>" <?php echo $row_class ?>>
+<<?php echo $sematic; ?> id="<?php echo $id ?>" <?php echo $row_class ?>>
 
 	<?php if ($componentArea): ?>
 		<?php if (!$pagebuilder): ?>
@@ -113,4 +113,4 @@ extract($displayData);
 			})
 		</script>
 	<?php endif; ?>
-</<?php echo $semantic; ?>>
+</<?php echo $sematic; ?>>

--- a/plugins/system/helixultimate/layouts/frontend/generate.php
+++ b/plugins/system/helixultimate/layouts/frontend/generate.php
@@ -8,7 +8,6 @@
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\FileLayout;
-use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Uri\Uri;
 
 defined('_JEXEC') or die();
@@ -55,7 +54,7 @@ if (!empty($template->params->get('layout'))) {
 extract($displayData);
 ?>
 
-<<?php echo $sematic; ?> id="<?php echo $id ?>" <?php echo $row_class ?>>
+<<?php echo $semantic; ?> id="<?php echo $id ?>" <?php echo $row_class ?>>
 
 	<?php if ($componentArea): ?>
 		<?php if (!$pagebuilder): ?>
@@ -114,4 +113,4 @@ extract($displayData);
 			})
 		</script>
 	<?php endif; ?>
-</<?php echo $sematic; ?>>
+</<?php echo $semantic; ?>>

--- a/plugins/system/helixultimate/src/Core/HelixUltimate.php
+++ b/plugins/system/helixultimate/src/Core/HelixUltimate.php
@@ -625,6 +625,8 @@ class HelixUltimate
 		$layout_path_carea  = (file_exists($carea_file)) ? $lyt_thm_path : JPATH_ROOT . '/plugins/system/helixultimate/layouts';
 		$layout_path_module = (file_exists($module_file)) ? $lyt_thm_path : JPATH_ROOT . '/plugins/system/helixultimate/layouts';
 
+		$rendered_sections = [];
+
 		foreach ($rows as $key => $row)
 		{
 			$modified_row = $this->get_current_row($row);
@@ -649,27 +651,25 @@ class HelixUltimate
 				$id = (isset($modified_row->settings->name) && $modified_row->settings->name) ? 'sp-' . OutputFilter::stringURLSafe($modified_row->settings->name) : 'sp-section-' . ($key + 1);
 				$row_class = $this->build_row_class($modified_row->settings);
 				$this->add_row_styles($modified_row->settings, $id);
-				$sematic = (isset($modified_row->settings->name) && $modified_row->settings->name) ? strtolower($modified_row->settings->name) : 'section';
+				$semantic = (isset($modified_row->settings->name) && $modified_row->settings->name) ? strtolower($modified_row->settings->name) : 'section';
 
-				
-
-				switch ($sematic)
+				switch ($semantic)
 				{
 					case "header":
-						$sematic = 'header';
+						$semantic = 'header';
 						break;
 
 					case "footer":
-						$sematic = 'footer';
+						$semantic = 'footer';
 						break;
 
 					default:
-						$sematic = 'section';
+						$semantic = 'section';
 						break;
 				}
 
 				$data = array(
-					'sematic' 			=> $sematic,
+					'semantic' 			=> $semantic,
 					'id' 				=> $id,
 					'row_class' 		=> $row_class,
 					'componentArea' 	=> $componentArea,
@@ -682,24 +682,36 @@ class HelixUltimate
 				$layout_path  = JPATH_ROOT . '/plugins/system/helixultimate/layouts';
 				$getLayout = new FileLayout('frontend.generate', $layout_path);
 
+				$rendered = $getLayout->render($data);
+
 				/**
 				 * If a section is named as `header` that means the section is for
 				 * the page header or site menu header.
 				 * But if the predefined_header option is enabled then
 				 * render the predefined header instead of the header section.
 				 */
-				if ($sematic === 'header')
+				if ($semantic === 'header')
 				{
 					if (!$this->params->get('predefined_header'))
 					{
-						$output .= $getLayout->render($data);
+						$output .= $rendered;
 					}
+				}
+				elseif ($semantic === 'footer')
+				{
+					$output .= $rendered;
 				}
 				else
 				{
-					$output .= $getLayout->render($data);
+					$rendered_sections[] = $rendered;
 				}
 			}
+		}
+
+		if (!empty($rendered_sections)) {
+        	$output = '<main id="sp-main">' . implode('', $rendered_sections) . '</main>' . $output;
+		} else {
+			$output .= implode('', $rendered_sections); 
 		}
 
 		return $output;

--- a/plugins/system/helixultimate/src/Core/HelixUltimate.php
+++ b/plugins/system/helixultimate/src/Core/HelixUltimate.php
@@ -651,25 +651,25 @@ class HelixUltimate
 				$id = (isset($modified_row->settings->name) && $modified_row->settings->name) ? 'sp-' . OutputFilter::stringURLSafe($modified_row->settings->name) : 'sp-section-' . ($key + 1);
 				$row_class = $this->build_row_class($modified_row->settings);
 				$this->add_row_styles($modified_row->settings, $id);
-				$semantic = (isset($modified_row->settings->name) && $modified_row->settings->name) ? strtolower($modified_row->settings->name) : 'section';
+				$sematic = (isset($modified_row->settings->name) && $modified_row->settings->name) ? strtolower($modified_row->settings->name) : 'section';
 
-				switch ($semantic)
+				switch ($sematic)
 				{
 					case "header":
-						$semantic = 'header';
+						$sematic = 'header';
 						break;
 
 					case "footer":
-						$semantic = 'footer';
+						$sematic = 'footer';
 						break;
 
 					default:
-						$semantic = 'section';
+						$sematic = 'section';
 						break;
 				}
 
 				$data = array(
-					'semantic' 			=> $semantic,
+					'sematic' 			=> $sematic,
 					'id' 				=> $id,
 					'row_class' 		=> $row_class,
 					'componentArea' 	=> $componentArea,
@@ -690,19 +690,19 @@ class HelixUltimate
 				 * But if the predefined_header option is enabled then
 				 * render the predefined header instead of the header section.
 				 */
-				if ($semantic === 'header')
+				if ($sematic === 'header')
 				{
 					if (!$this->params->get('predefined_header'))
 					{
 						$output .= $rendered;
 					}
 				}
-				elseif ($semantic === 'footer')
+				elseif ($sematic === 'footer')
 				{
 					$output .= $rendered;
 				}
 				else
-				{
+				{	
 					$rendered_sections[] = $rendered;
 				}
 			}

--- a/plugins/system/helixultimate/src/Core/HelixUltimate.php
+++ b/plugins/system/helixultimate/src/Core/HelixUltimate.php
@@ -626,6 +626,8 @@ class HelixUltimate
 		$layout_path_module = (file_exists($module_file)) ? $lyt_thm_path : JPATH_ROOT . '/plugins/system/helixultimate/layouts';
 
 		$rendered_sections = [];
+		$header = '';
+		$footer = '';
 
 		foreach ($rows as $key => $row)
 		{
@@ -694,12 +696,12 @@ class HelixUltimate
 				{
 					if (!$this->params->get('predefined_header'))
 					{
-						$output .= $rendered;
+						$header .= $rendered;
 					}
 				}
 				elseif ($sematic === 'footer')
 				{
-					$output .= $rendered;
+					$footer .= $rendered;
 				}
 				else
 				{	
@@ -709,9 +711,7 @@ class HelixUltimate
 		}
 
 		if (!empty($rendered_sections)) {
-        	$output = '<main id="sp-main">' . implode('', $rendered_sections) . '</main>' . $output;
-		} else {
-			$output .= implode('', $rendered_sections); 
+        	$output = $header . '<main id="sp-main">' . implode('', $rendered_sections) . '</main>' . $footer;
 		}
 
 		return $output;

--- a/templates/shaper_helixultimate/index.php
+++ b/templates/shaper_helixultimate/index.php
@@ -164,9 +164,7 @@ if ($custom_js = $this->params->get('custom_js', null))
 		<div class="body-wrapper">
 			<div class="body-innerwrapper">
 				<?php echo $theme->getHeaderStyle(); ?>
-				<main id="sp-main">
-					<?php $theme->render_layout(); ?>
-				</main>
+				<?php $theme->render_layout(); ?>
 			</div>
 		</div>
 


### PR DESCRIPTION
- Fix typo in variable name from 'sematic' to 'semantic'
- Remove redundant main tag wrapper from template
- Refactor section rendering logic to properly wrap non-header/footer sections in main tag
- Store rendered sections separately for better organization before final output