### PR TITLE
refactor(menu): standardize item ID handling across menu components

### DIFF
--- a/plugins/system/helixultimate/src/Core/Classes/HelixultimateMenu.php
+++ b/plugins/system/helixultimate/src/Core/Classes/HelixultimateMenu.php
@@ -496,6 +496,13 @@ class HelixultimateMenu
 
 					foreach ($col->items as $builder_item)
 					{
+						$cellItemId = (int) ($builder_item->item_id ?? $builder_item->id ?? 0);
+
+						if ($cellItemId === 0)
+						{
+							continue;
+						}
+
 						$li_head = '';
 
 						if ($builder_item->type === 'menu_item')
@@ -504,7 +511,7 @@ class HelixultimateMenu
 						}
 
 						$item_class = array(
-							'item-' . $builder_item->item_id,
+							'item-' . $cellItemId,
 							$builder_item->type,
 							$li_head
 						);
@@ -513,14 +520,14 @@ class HelixultimateMenu
 
 						if ($builder_item->type === 'module')
 						{
-							$this->menu .= $this->load_module($builder_item->item_id);
+							$this->menu .= $this->load_module($cellItemId);
 						}
 						elseif ($builder_item->type === 'menu_item')
 						{
-							if (!empty($this->_items[$builder_item->item_id]))
+							if (!empty($this->_items[$cellItemId]))
 							{
-								$item 	= $this->_items[$builder_item->item_id];
-								$items  = isset($this->children[$builder_item->item_id]) ? $this->children[$builder_item->item_id] : array();
+								$item 	= $this->_items[$cellItemId];
+								$items  = isset($this->children[$cellItemId]) ? $this->children[$cellItemId] : array();
 
 								$firstitem = count($items) ? $items[0]->id : 0;
 

--- a/plugins/system/helixultimate/src/Platform/Builders/MegaMenuBuilder.php
+++ b/plugins/system/helixultimate/src/Platform/Builders/MegaMenuBuilder.php
@@ -168,6 +168,13 @@ class MegaMenuBuilder extends Builder
 	 */
 	public function getTitle($item)
 	{
+		$itemId = (int) ($item->item_id ?? $item->id ?? 0);
+
+		if ($itemId === 0)
+		{
+			return '';
+		}
+
 		$element = null;
 
 		if ($item->type === 'module')
@@ -176,7 +183,7 @@ class MegaMenuBuilder extends Builder
 
 			foreach ($modules as $mod)
 			{
-				if ((int) $mod->id === (int) $item->item_id)
+				if ((int) $mod->id === $itemId)
 				{
 					$element = $mod;
 					break;
@@ -186,7 +193,7 @@ class MegaMenuBuilder extends Builder
 		else
 		{
 			$menu = new SiteMenu;
-			$element = $menu->getItem($item->item_id);
+			$element = $menu->getItem($itemId);
 		}
 
 		return !empty($element) ? $element->title : '';

--- a/plugins/system/helixultimate/src/Platform/Helper.php
+++ b/plugins/system/helixultimate/src/Platform/Helper.php
@@ -1378,15 +1378,16 @@ class Helper
 						}
 
 						$cell = (array) $cell;
-						$type = ($cell['type'] ?? '') === 'module' ? 'module' : 'menu';
+						$type = ($cell['type'] ?? '') === 'module' ? 'module' : 'menu_item';
+						$cellId = (string) (int) ($cell['item_id'] ?? $cell['id'] ?? 0);
 						$cleanCell = [
 							'type' => $type,
-							'id' => (string) (int) ($cell['id'] ?? 0),
+							'item_id' => $cellId,
 						];
 
 						if ($type === 'module')
 						{
-							$cleanCell['moduleId'] = (string) (int) ($cell['moduleId'] ?? $cell['id'] ?? 0);
+							$cleanCell['moduleId'] = (string) (int) ($cell['moduleId'] ?? $cell['item_id'] ?? $cell['id'] ?? 0);
 						}
 
 						$cleanColumn['items'][] = $cleanCell;

--- a/plugins/system/helixultimate/tests/security/Phase07MegaMenuSecurityTest.php
+++ b/plugins/system/helixultimate/tests/security/Phase07MegaMenuSecurityTest.php
@@ -124,6 +124,43 @@ final class Phase07MegaMenuSecurityTest
 			$failures[] = 'sanitizeMegaMenuSettings should preserve valid layout structure.';
 		}
 
+		$jsLayout = Helper::sanitizeMegaMenuSettings([
+			'layout' => [
+				[
+					'type' => 'row',
+					'attr' => [
+						[
+							'type' => 'column',
+							'colGrid' => '6',
+							'items' => [
+								[
+									'type' => 'menu_item',
+									'item_id' => '2933',
+								],
+								[
+									'type' => 'module',
+									'item_id' => '311',
+								],
+							],
+						],
+					],
+				],
+			],
+		]);
+
+		$menuCell = $jsLayout['layout'][0]['attr'][0]['items'][0] ?? [];
+		$moduleCell = $jsLayout['layout'][0]['attr'][0]['items'][1] ?? [];
+
+		if (($menuCell['type'] ?? null) !== 'menu_item' || ($menuCell['item_id'] ?? null) !== '2933')
+		{
+			$failures[] = 'sanitizeMegaMenuSettings should preserve menu_item cells with item_id from the builder payload.';
+		}
+
+		if (($moduleCell['type'] ?? null) !== 'module' || ($moduleCell['item_id'] ?? null) !== '311' || ($moduleCell['moduleId'] ?? null) !== '311')
+		{
+			$failures[] = 'sanitizeMegaMenuSettings should preserve module cells with item_id and moduleId from the builder payload.';
+		}
+
 		return $failures;
 	}
 }


### PR DESCRIPTION
Update the HelixultimateMenu, Helper, and MegaMenuBuilder classes to consistently use a unified method for retrieving item IDs. This change improves code readability and reduces potential errors by ensuring that item IDs are always processed in the same way. Additionally, enhance the security test for mega menu settings to validate the preservation of item IDs in the layout structure.